### PR TITLE
Added types exports

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -118,5 +118,5 @@ add.only =
 
 add.skip = (...args) => ({ name: 'skip' })
 
-export { add, Add, SkipResult }
+export { add, Add, SkipResult, Deferred }
 export default add

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -36,5 +36,5 @@ const complete: Complete = (fn = defaultComplete) => async (config) => (
   return suiteObj
 }
 
-export { complete, Complete }
+export { complete, Complete, CompleteFn }
 export default complete

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -12,5 +12,5 @@ const configure: Configure = (config) => ({
   entries: config,
 })
 
-export { ConfigureResult }
+export { configure, Configure, ConfigureResult }
 export default configure

--- a/src/cycle.ts
+++ b/src/cycle.ts
@@ -88,5 +88,5 @@ const cycle: Cycle = (fn = defaultCycle) => async (config) => (suiteObj) => {
   return suiteObj
 }
 
-export { cycle, Cycle }
+export { cycle, Cycle, CycleFn }
 export default cycle

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
+export {
+  Options,
+  Config,
+  SaveOptions,
+  CaseResult,
+  CaseResultWithDiff,
+  Summary
+} from './internal/common-types'
+
 import add from './add'
 import complete from './complete'
 import configure from './configure'
@@ -5,7 +14,12 @@ import cycle from './cycle'
 import save from './save'
 import suite from './suite'
 
-export { add, complete, configure, cycle, save, suite }
+export * from './add'
+export * from './complete'
+export * from './configure'
+export * from './cycle'
+export * from './save'
+export * from './suite'
 
 export default {
   add,

--- a/src/suite.ts
+++ b/src/suite.ts
@@ -49,5 +49,5 @@ const suite: SuiteFn = async (name, ...entries) => {
   })
 }
 
-export { suite }
+export { suite, SuiteFn, Entry }
 export default suite


### PR DESCRIPTION
This PR adds **types exports**.

In cases where I want to programmatically prepare different configurations in a different context and then passing them to `add()`, `cycle()`, `complete()` etc... I need to have access to the user-facing types by the library. I went a little further and figured which types from each file are "public api" so I added them to exports, basically completing work that was already happening, and replaced the main entry exports with `*` (asterisk) for the add, cycle, etc. modules. This would take care the fact that whatever is exported by these public apis is also exported in the main entry.
